### PR TITLE
Add transformValueDeclarations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ require('postcss-custom-properties-transformer')({
     - `property` `<String>` - The custom property name that's being transformed. The `--` prefix is omitted
     - `filepath` `<String>` - The path to the file where the custom property is being transformed
     - `css` `<String>` - The entire CSS code of the file
+- `transformValueDeclarations` `<Boolean>` - If enabled, custom properties in `@value` declarations will also be considered for transformation

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,9 @@ const {stringify: string} = JSON;
 // https://github.com/postcss/postcss-custom-properties/blob/1e1ef6b/src/lib/transform-properties.js#L37
 const customPropertyPtrn = /^--[A-z][\w-]*$/;
 const varFnPtrn = /(^|[^\w-])var\([\W\w]+\)/;
+// From postcss-modules-values
+// https://github.com/css-modules/postcss-modules-values/blob/3851eec/src/index.js#L6
+const matchValueDefinition = /(?:\s+|^)[\w-]+:?(.*?)$/;
 const name = 'postcss-custom-properties-transformer';
 
 function markHashUsed(map, propertyName, originalPropertyName) {
@@ -40,6 +43,8 @@ const customPropertiesTransformer = postcss.plugin(name, options => {
 	assert(options && options.transformer, `[${name}] a transformer must be passed in`);
 	assert(typeof options.transformer === 'function', `[${name}] transformer must be a function`);
 
+	const {transformValueDeclarations = false} = options;
+
 	const transformer = createTransformer(options.transformer);
 
 	return root => {
@@ -47,6 +52,8 @@ const customPropertiesTransformer = postcss.plugin(name, options => {
 			filepath: root.source.input.file,
 			css: root.source.input.css,
 		});
+
+		const process = value => processPropertyValue(value, customProperty => transformer(customProperty, data));
 
 		root.walkDecls(decl => {
 			// Custom property declaration
@@ -56,9 +63,16 @@ const customPropertiesTransformer = postcss.plugin(name, options => {
 
 			// Custom property usage
 			if (varFnPtrn.test(decl.value)) {
-				decl.value = processPropertyValue(decl.value, customProperty => transformer(customProperty, data));
+				decl.value = process(decl.value);
 			}
 		});
+
+		if (transformValueDeclarations) {
+			root.walkAtRules('value', atRule => {
+				const [, value] = atRule.params.match(matchValueDefinition);
+				atRule.params = atRule.params.replace(value, process(value));
+			});
+		}
 	};
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,11 @@ const customPropertiesTransformer = postcss.plugin(name, options => {
 		if (transformValueDeclarations) {
 			root.walkAtRules('value', atRule => {
 				const [, value] = atRule.params.match(matchValueDefinition);
+
+				if (!varFnPtrn.test(value)) {
+					return;
+				}
+
 				atRule.params = atRule.params.replace(value, process(value));
 			});
 		}

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -22,6 +22,7 @@ Array [
 
 	@value color: var(--app-color);
 	@value largeFontSize: calc(var(--app-font-size) * 2);
+	@value staticSelectorValue: .someSelector;
 	",
   "
 	:root {
@@ -67,6 +68,7 @@ Array [
 
 	@value color: var(--color);
 	@value largeFontSize: calc(var(--font-size) * 2);
+	@value staticSelectorValue: .someSelector;
 	",
   "
 	:root {
@@ -112,6 +114,7 @@ Array [
 
 	@value color: var(--color);
 	@value largeFontSize: calc(var(--font-size) * 2);
+	@value staticSelectorValue: .someSelector;
 	",
   "
 	:root {
@@ -157,6 +160,7 @@ Array [
 
 	@value color: var(--color);
 	@value largeFontSize: calc(var(--font-size) * 2);
+	@value staticSelectorValue: .someSelector;
 	",
   "
 	:root {
@@ -202,6 +206,7 @@ Array [
 
 	@value color: var(--color);
 	@value largeFontSize: calc(var(--font-size) * 2);
+	@value staticSelectorValue: .someSelector;
 	",
   "
 	:root {

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transform options value declarations 1`] = `
+Array [
+  "
+	.button {
+		--app-color: red;
+		--app-font-size: 24px;
+		background: var(--app-color);
+		border-color: var(--app-color);
+		font-size: var(--app-font-size);
+	}
+
+	.input {
+		--app-color: red;
+		--app-font-size: 24px;
+		background: var(--app-color);
+		border-color: var(--app-color);
+		font-size: var(--app-font-size);
+		border: 1px solid var(--app-color);
+	}
+
+	@value color: var(--app-color);
+	@value largeFontSize: calc(var(--app-font-size) * 2);
+	",
+  "
+	:root {
+		--app-color: red;
+		--app-font-size: 24px;
+		--app-large-font-size: calc(var(--app-font-size) * 2);
+	}
+	.section {
+		background: var(--app-color);
+		border-color: var(--app-color);
+		font-size: var(--app-font-size);
+	}
+
+	.heading {
+		background: var(--app-color);
+		border-color: var(--app-color);
+		font-size: var(--app-font-size);
+		border: 1px solid var(--app-color);
+	}
+	",
+]
+`;
+
 exports[`transformer function custom hash - scoped to file 1`] = `
 Array [
   "
@@ -19,6 +64,9 @@ Array [
 		font-size: var(--b682a4);
 		border: 1px solid var(--ae7621);
 	}
+
+	@value color: var(--color);
+	@value largeFontSize: calc(var(--font-size) * 2);
 	",
   "
 	:root {
@@ -61,6 +109,9 @@ Array [
 		font-size: var(--9b1d0a);
 		border: 1px solid var(--70dda5);
 	}
+
+	@value color: var(--color);
+	@value largeFontSize: calc(var(--font-size) * 2);
 	",
   "
 	:root {
@@ -103,6 +154,9 @@ Array [
 		font-size: var(--🔥-font-size);
 		border: 1px solid var(--🔥-color);
 	}
+
+	@value color: var(--color);
+	@value largeFontSize: calc(var(--font-size) * 2);
 	",
   "
 	:root {
@@ -145,6 +199,9 @@ Array [
 		font-size: var(--app-font-size);
 		border: 1px solid var(--app-color);
 	}
+
+	@value color: var(--color);
+	@value largeFontSize: calc(var(--font-size) * 2);
 	",
   "
 	:root {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -16,6 +16,9 @@ const fixtures = {
 		font-size: var(--font-size);
 		border: 1px solid var(--color);
 	}
+
+	@value color: var(--color);
+	@value largeFontSize: calc(var(--font-size) * 2);
 	`,
 	'file-b.css': `
 	:root {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -19,6 +19,7 @@ const fixtures = {
 
 	@value color: var(--color);
 	@value largeFontSize: calc(var(--font-size) * 2);
+	@value staticSelectorValue: .someSelector;
 	`,
 	'file-b.css': `
 	:root {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -69,3 +69,16 @@ describe('transformer function', () => {
 		expect(output).toMatchSnapshot();
 	});
 });
+
+describe('transform options', () => {
+	test('value declarations', async () => {
+		const output = await transform(fixtures, {
+			transformValueDeclarations: true,
+			transformer({property}) {
+				return `app-${property}`;
+			},
+		});
+
+		expect(output).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
Title.

Currently, this plugin doesn't transform custom properties in a value declaration (as it's technically not a css declaration).

While it's technically possible to resolve values to their final resting place before running this plugin's transform, that prevents filepath-sensitive transforms.

This PR adds the `transformValueDeclarations` option. When enabled, the plugin will also consider custom properties usages in values for transformation.

I've added this as an opt-in option to prevent it from being a breaking change.

Thanks for your work on this plugin!